### PR TITLE
Filter adjustments

### DIFF
--- a/BnsPerformanceFix.cs
+++ b/BnsPerformanceFix.cs
@@ -13,7 +13,7 @@ namespace BnsPerformanceFix
     {
         public static void FilterLocalDatInPlace(string datfile, Filter filter)
         {
-            var is64 = datfile.EndsWith("64.dat");
+            var is64 = datfile.Contains("64");
             var extracted = ExtractDat(datfile, is64);
             var binfile = Path.Combine(extracted, is64 ? "localfile64.bin" : "localfile.bin");
             FilterLocalBinInPlace(binfile, filter);

--- a/filters/playable.txt
+++ b/filters/playable.txt
@@ -106,9 +106,9 @@ Msg.Party.Member.Dead
 Msg.Pc.Dead
 
 # combat log (for self and target only)
--Msg.Battle.Party.*
--Msg.Battle.Other.*
-Msg.Battle.*
+#-Msg.Battle.Party.*
+#-Msg.Battle.Other.*
+#Msg.Battle.*
 
 # IA loot (for linking loot to the raid)
 Item.Name2.General_Grocery_SpecialMaterial_1239

--- a/filters/playable.txt
+++ b/filters/playable.txt
@@ -110,6 +110,24 @@ Msg.Pc.Dead
 #-Msg.Battle.Other.*
 #Msg.Battle.*
 
+# Attributes for items/unity/compound
+Name.Item.boss-*
+Name.Item.pc-*
+Name.Item.Symbol.*
+Name.Item.category
+Name.Item.attack-*
+Name.Item.defend-*
+Name.Item.Required.Level
+Name.Item.Required.Level2
+Name.Item.Required.Everyone
+
+#Countdown Timer
+Name.DuelLobbyTimer.*
+
+# Party member Lvl
+Name.Party.Member.*
+Name.Level2.Level.*
+
 # IA loot (for linking loot to the raid)
 Item.Name2.General_Grocery_SpecialMaterial_1239
 Item.Name2.General_Grocery_Coin_0220


### PR DESCRIPTION
Filter adjustments to add in missing text from older builds.
Adjusted bit check so 64-bit local dats can have an extension other than 64.dat (i.e local64.dat.backup) 